### PR TITLE
Fix incorrect grouping of issue/PR comments

### DIFF
--- a/ghmap/mapping/activity_mapper.py
+++ b/ghmap/mapping/activity_mapper.py
@@ -70,15 +70,18 @@ class ActivityMapper:
                 validated.append(action)
                 continue
 
-            is_valid = any(
+            is_valid = all(
+                not any(target["action"] == rule["target_action"] for target in gathered) or
                 all(
-                    self._get_nested_value(action["details"], field["field"]) ==
-                    self._get_nested_value(target["details"], field["target_field"])
-                    for field in rule["fields"]
+                    all(
+                        self._get_nested_value(action["details"], field["field"]) ==
+                        self._get_nested_value(target["details"], field["target_field"])
+                        for field in rule["fields"]
+                    )
+                    for target in gathered
+                    if target["action"] == rule["target_action"] and target["event_id"] != action["event_id"]
                 )
                 for rule in config["validate_with"]
-                for target in gathered
-                if target["event_id"] != action["event_id"]  # Skip the same action
             )
 
             (validated if is_valid else invalid).append(action)


### PR DESCRIPTION
- This PR fixes an issue where all `CreateIssueComment`, `CreatePullRequestComment`, etc. actions were incorrectly grouped into a single activity, even when related to different issues or PRs.
- Now, comments are only grouped if they belong to the same `issue.number` or `pull_request.number`.

### Changes  
- Updated validation logic in `_validate_gathered_actions` to enforce issue/PR consistency.