### PR TITLE
fix import config files in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ ghmap = "ghmap.cli:main"
 packages = ["ghmap", "ghmap.preprocess", "ghmap.mapping"]
 
 [tool.setuptools.package-data]
-ghmap = ["config/event_to_action.json", "config/action_to_activity.json"]
+ghmap = ["config/*.json"]
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
This PR fixes the issue where the config/ files (JSON mappings) were not included in the package when installed via pip.

Previously, the package was distributed without the necessary event-to-action and action-to-activity JSON files